### PR TITLE
More flexible InputTag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-spm-deps-{{ checksum "Package.swift" }}
+            - v3-spm-deps-{{ checksum "Package.swift" }}
       - run:
           name: Install CMySQL and CTLS
           command: |
@@ -36,7 +36,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-spm-deps-{{ checksum "Package.swift" }}
+            - v4-spm-deps-{{ checksum "Package.swift" }}
       - run:
           name: Copy Package file
           command: cp Package.swift res

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ api.patch("todos", Todo.parameter, use: apiTodoController.update)
 When building your HTML form using Leaf you can add inputs for your model's fields like so:
 
 ```
-#submissions:input("title", "text", "Enter title", "Please enter a title")
+#submissions:text("title", "Enter title", "Please enter a title")
 ```
 
 This will render a form group with an input and any errors stored in the field cache for the "title" field. This produces the following Bootstrap 4 style HTML (with in this case a validation error):
@@ -224,7 +224,7 @@ This will render a form group with an input and any errors stored in the field c
 </div>
 ```
 
-> Note: Currently only "input" with variants for email, password and text is supported.
+> Note: Currently only "text", "email" and "pasword" is supported.
 
 Before we can use the tag we have to register it in `configure.swift`. We'll use a helper function from the [`Sugar`](https://github.com/nodes-vapor/sugar/tree/vapor-3) package. 
 

--- a/Sources/Submissions/FieldEntry.swift
+++ b/Sources/Submissions/FieldEntry.swift
@@ -1,15 +1,15 @@
 import Vapor
 
-/// A field with a key
+/// A field with a key.
 public struct FieldEntry<S: Submittable> {
     var key: String
     var field: Field<S>
 
     /// Create a new `FieldEntry`.
     /// - Parameters:
-    ///   - keyPath:
+    ///   - keyPath: Path to the value for the field.
     ///   - field: A field.
-    /// - Throws: When determining the key from the key path fails
+    /// - Throws: When determining the key from the key path fails.
     init<A: Reflectable, B>(keyPath: KeyPath<A, B>, field: Field<S>) throws {
         guard let paths = try A.reflectProperty(forKey: keyPath)?.path, paths.count > 0 else {
             throw SubmissionError.invalidPathForKeyPath

--- a/Sources/Submissions/SubmissionType.swift
+++ b/Sources/Submissions/SubmissionType.swift
@@ -19,6 +19,7 @@ extension SubmissionType {
     /// Make a field entry corresponding to a key path.
     ///
     /// - Parameters:
+    ///   - keyPath: Path to the value on the submission type.
     ///   - label: A label describing this field.
     ///   - value: The value for this field.
     ///   - validators: The validators to use when validating the value.
@@ -54,6 +55,7 @@ extension SubmissionType {
     /// Make a field entry corresponding to a key path with an optional value.
     ///
     /// - Parameters:
+    ///   - keyPath: Path to the value on the submission type.
     ///   - label: A label describing this field.
     ///   - value: The value for this field.
     ///   - validators: The validators to use when validating the value.

--- a/Sources/Submissions/SubmissionsProvider.swift
+++ b/Sources/Submissions/SubmissionsProvider.swift
@@ -24,7 +24,6 @@ public final class SubmissionsProvider: Provider {
         let tags: MutableLeafTagConfig = try container.make()
         let paths = config.tagTemplatePaths
         tags.use([
-            "submissions:input": InputTag(),
             "submissions:email": InputTag(templatePath: paths.emailField),
             "submissions:password": InputTag(templatePath: paths.passwordField),
             "submissions:text": InputTag(templatePath: paths.textField)

--- a/Sources/Submissions/SubmissionsProvider.swift
+++ b/Sources/Submissions/SubmissionsProvider.swift
@@ -1,4 +1,5 @@
 import Service
+import Leaf
 import Vapor
 
 /// A provider that registers a FieldCache.
@@ -18,13 +19,15 @@ public final class SubmissionsProvider: Provider {
 
     /// See `Provider`
     public func didBoot(_ container: Container) throws -> Future<Void> {
-        return .done(on: container)
-    }
-}
+        let tags = try container.make(LeafTagConfig.self)
+        let paths = config.tagTemplatePaths
+        tags.use([
+            "submissions:input": InputTag(),
+            "submissions:email": InputTag(templatePath: paths.emailField),
+            "submissions:password": InputTag(templatePath: paths.passwordField),
+            "submissions:text": InputTag(templatePath: paths.textField)
+        ])
 
-extension SubmissionsProvider {
-    /// The Submission related tags.
-    public static var tags: [String: TagRenderer] {
-        return ["submissions:input": InputTag()]
+        return .done(on: container)
     }
 }

--- a/Sources/Submissions/SubmissionsProvider.swift
+++ b/Sources/Submissions/SubmissionsProvider.swift
@@ -14,6 +14,7 @@ public final class SubmissionsProvider: Provider {
     
     /// See `Provider`
     public func register(_ services: inout Services) throws {
+        try services.register(MutableLeafTagConfigProvider())
         services.register(config)
         services.register { _ in FieldCache() }
     }

--- a/Sources/Submissions/SubmissionsProvider.swift
+++ b/Sources/Submissions/SubmissionsProvider.swift
@@ -20,7 +20,7 @@ public final class SubmissionsProvider: Provider {
 
     /// See `Provider`
     public func didBoot(_ container: Container) throws -> Future<Void> {
-        let tags = try container.make(MutableLeafTagConfig.self)
+        let tags: MutableLeafTagConfig = try container.make()
         let paths = config.tagTemplatePaths
         tags.use([
             "submissions:input": InputTag(),

--- a/Sources/Submissions/SubmissionsProvider.swift
+++ b/Sources/Submissions/SubmissionsProvider.swift
@@ -1,5 +1,6 @@
-import Service
 import Leaf
+import Service
+import Sugar
 import Vapor
 
 /// A provider that registers a FieldCache.
@@ -19,7 +20,7 @@ public final class SubmissionsProvider: Provider {
 
     /// See `Provider`
     public func didBoot(_ container: Container) throws -> Future<Void> {
-        let tags = try container.make(LeafTagConfig.self)
+        let tags = try container.make(MutableLeafTagConfig.self)
         let paths = config.tagTemplatePaths
         tags.use([
             "submissions:input": InputTag(),

--- a/Sources/Submissions/Tags/InputTag.swift
+++ b/Sources/Submissions/Tags/InputTag.swift
@@ -25,21 +25,6 @@ public final class InputTag: TagRenderer {
         }
     }
 
-    public init() {
-        c = { tag, inputData in
-            let body = try tag.requireBody()
-
-            return tag.serializer.serialize(ast: body)
-                .flatMap { view in
-                    try tag
-                        .container
-                        .make(TemplateRenderer.self)
-                        .render(template: view.data, inputData)
-                }
-                .map { .data($0.data) }
-        }
-    }
-
     public func render(tag: TagContext) throws -> Future<TemplateData> {
         let data = try tag.submissionsData()
 


### PR DESCRIPTION
Do not merge! This is awaiting https://github.com/nodes-vapor/sugar/pull/56 (or https://github.com/vapor/leaf/pull/113).

Alternative to https://github.com/nodes-vapor/submissions/pull/20

- support registering your own paths to leaf files
- support supplying body instead of leaf (experimental)
- use following names for tags:
  - submissions:input (expects body)
  - submissions:email
  - submissions:password
  - submissions:text
- register leaf tags in new proposed way