### PR TITLE
Also populate fields on success while validating

### DIFF
--- a/Sources/Submissions/SubmissionType.swift
+++ b/Sources/Submissions/SubmissionType.swift
@@ -128,11 +128,11 @@ extension SubmissionType {
             }
             .map { errors in
                 let validationErrors = [String: [ValidationError]](uniqueKeysWithValues: errors)
+                try req.populateFields(
+                    with: fields.mapValues(AnyField.init),
+                    andErrors: validationErrors
+                )
                 if !validationErrors.isEmpty {
-                    try req.populateFields(
-                        with: fields.mapValues(AnyField.init),
-                        andErrors: validationErrors
-                    )
                     throw SubmissionValidationError()
                 }
                 return self


### PR DESCRIPTION
This supports the situation where throwing an error later still has the
fields filled with the submitted values.