### PR TITLE
Use 'true' instead of '1' for checkbox value

### DIFF
--- a/Resources/Views/Submissions/Fields/checkbox-input.leaf
+++ b/Resources/Views/Submissions/Fields/checkbox-input.leaf
@@ -1,5 +1,5 @@
 <div class="form-group form-check">
-    <input type="checkbox" class="form-check-input" id="#(key)" name="#(key)" value="1" #if(value) { checked }>
+    <input type="checkbox" class="form-check-input" id="#(key)" name="#(key)" value="true" #if(value) { checked }>
 
     #if(label) {
         <label class="form-check-label" for="#(key)">#(label)</label>


### PR DESCRIPTION
To be compatible with the parsing of `Bool(from:String)` and the (upcoming version of) `vapor/multipart` I would like to use `true` instead of `1` as default value.