### PR TITLE
Make `TagContext.submissionsData` ignore a trailing "[]"

### DIFF
--- a/Sources/Submissions/Tags/SubmissionsData.swift
+++ b/Sources/Submissions/Tags/SubmissionsData.swift
@@ -23,8 +23,11 @@ public extension TagContext {
             throw error(reason: "Invalid parameter type.")
         }
 
-        let field = fieldCache[valueFor: key]
-        let errors = fieldCache[errorsFor: key]
+        // Vapor's `URLEncodedFormDecoder` requires array-valued arguments to be encoded with a trailing `[]` in the
+        // form data. However, key paths can't contain `[]`, so we strip that part when searching for a tag's field.
+        let keyPath = key.components(separatedBy: "[]")[0]
+        let field = fieldCache[valueFor: keyPath]
+        let errors = fieldCache[errorsFor: keyPath]
 
         return SubmissionsData(
             key: key,


### PR DESCRIPTION
Motivation: Vapor's `URLEncodedFormDecoder` expects array-typed fields to end with a `[]`. For example, to decode

```
struct Args: Codable {
  let options: [String]
}
```

one would need to pass in a query string/form of the form `options[]=foo&options[]=bar`. To achieve that, the input field's name in the Leaf template needs to be `options[]`, however, the Field's name is derived from its key path, which is `options`. To make this `submissionsData()` find the correct field, we also attempt searching for the stripped field path.