### PR TITLE
Update Submittable.swift

### DIFF
--- a/Sources/Submissions/Submittable.swift
+++ b/Sources/Submissions/Submittable.swift
@@ -37,7 +37,8 @@ extension Submittable {
         for submission: Submission? = nil,
         given existing: Self? = nil
     ) throws -> [Field] {
-        return try Submission.makeFields(for: submission ?? existing?.makeSubmission()) +
+        let submission = submission ?? existing?.makeSubmission()
+        return try Submission.makeFields(for: submission) +
             makeAdditionalFields(for: submission, given: existing)
     }
 }


### PR DESCRIPTION
In case I want to use `makeAdditionalFields` for handling validation on a field, I would expect the same behaviour on the `Submission` that's passed in similar to `makeFields`.

In those cases, I can omit the `Field` from `makeFields` and move it to `makeAdditionalFields` instead.