### PR TITLE
Add select tag

### DIFF
--- a/Resources/Views/Submissions/Fields/select-input.leaf
+++ b/Resources/Views/Submissions/Fields/select-input.leaf
@@ -1,0 +1,24 @@
+<div class="form-group">
+    #if(label) {
+        <label for="#(key)">#(label)</label>
+    }
+    
+    <select class="form-control #if(hasErrors) { is-invalid }" id="#(key)" name="#(key)" #if(isRequired) { required }>
+        <option value="" #if(isRequired) { disabled } selected>#(placeholder)</option>
+        #for(option in options) {
+            <option value="#(option.id)" #if(value == option.id) { selected }>#(option.value)</option>
+        }
+    </select>
+
+    #if(helpText) {
+        <small id="#(key)Help" class="form-text text-muted">#(helpText)</small>
+    }
+
+    #if(hasErrors) {
+        <div class='invalid-feedback'>
+            #for(error in errors) {
+                <div>#(error)</div>
+            }
+        </div>
+    }
+</div>

--- a/Sources/Submissions/Tags/LeafTagConfig+submissions.swift
+++ b/Sources/Submissions/Tags/LeafTagConfig+submissions.swift
@@ -11,11 +11,12 @@ extension LeafTagConfig {
         use([
             "submissions:checkbox": InputTag(templatePath: paths.checkboxField),
             "submissions:email": InputTag(templatePath: paths.emailField),
-            "submissions:file": InputTag(templatePath: paths.fileField),
+            "submissions:file": FileTag(templatePath: paths.fileField),
             "submissions:hidden": InputTag(templatePath: paths.hiddenField),
             "submissions:password": InputTag(templatePath: paths.passwordField),
             "submissions:text": InputTag(templatePath: paths.textField),
-            "submissions:textarea": InputTag(templatePath: paths.textareaField)
+            "submissions:textarea": InputTag(templatePath: paths.textareaField),
+            "submissions:select": SelectTag(templatePath: paths.selectField)
         ])
     }
 }

--- a/Sources/Submissions/Tags/SelectTag.swift
+++ b/Sources/Submissions/Tags/SelectTag.swift
@@ -1,0 +1,108 @@
+import TemplateKit
+
+/// A tag that renders a template file corresponding to a select input element.
+public final class SelectTag: TagRenderer {
+    private static let optionIDKey = "id"
+    private static let optionValueKey = "value"
+
+    public struct Option: Encodable, TemplateDataRepresentable {
+        let id: String
+        let value: String
+
+        public func convertToTemplateData() throws -> TemplateData {
+            return .dictionary([
+                SelectTag.optionIDKey: .string(id),
+                SelectTag.optionValueKey: .string(value)
+            ])
+        }
+    }
+
+    struct InputData: Encodable {
+        let key: String
+        let value: String?
+        let options: [Option]
+        let label: String?
+        let isRequired: Bool
+        let errors: [String]
+        let hasErrors: Bool
+        let placeholder: String?
+        let helpText: String?
+    }
+
+    /// Create a new `SelectTag`.
+    ///
+    /// - Parameter templatePath: path to the template file to render
+    public init(templatePath: String) {
+        render = { tag, inputData in
+            try tag.requireNoBody()
+            return try tag
+                .container
+                .make(TemplateRenderer.self)
+                .render(templatePath, inputData)
+                .map { .data($0.data) }
+        }
+    }
+
+    private let render: (TagContext, InputData) throws -> Future<TemplateData>
+
+    /// See `TagRenderer`.
+    public func render(tag: TagContext) throws -> Future<TemplateData> {
+        let data = try tag.submissionsData()
+
+        let rawOptions = tag.parameters[safe: 1]?.array ?? []
+        let options: [Option] = rawOptions.compactMap { data in
+            guard
+                let id = data.dictionary?[SelectTag.optionIDKey]?.string,
+                let value = data.dictionary?[SelectTag.optionValueKey]?.string
+            else {
+                return nil
+            }
+            return SelectTag.Option(id: id, value: value)
+        }
+
+        let placeholder = tag.parameters[safe: 2]?.string
+        let helpText = tag.parameters[safe: 3]?.string
+
+        return (data.errors ?? tag.future([])).flatMap {
+            let inputData = InputData(
+                key: data.key,
+                value: data.value,
+                options: options,
+                label: data.label,
+                isRequired: data.isRequired,
+                errors: $0,
+                hasErrors: !$0.isEmpty,
+                placeholder: placeholder,
+                helpText: helpText
+            )
+            return try self.render(tag, inputData)
+        }
+    }
+}
+
+// MARK: Convenience helpers
+
+/// A type that can be used as an option for the SelectTag.
+protocol Selectable {
+    func optionID() throws -> String?
+    func optionValue() throws -> String?
+}
+
+extension Array where Element: Selectable {
+    /// Generates the options for the SelectTag.
+    var options: [SelectTag.Option] {
+        return self.compactMap { option in
+            guard
+                let id = try? option.optionID(),
+                let unwrappedId = id,
+                let value = try? option.optionValue(),
+                let unwrappedValue = value
+            else { return nil }
+
+            return SelectTag.Option(
+                id: unwrappedId,
+                value: unwrappedValue
+            )
+        }
+    }
+}

--- a/Sources/Submissions/Tags/TagTemplatePaths.swift
+++ b/Sources/Submissions/Tags/TagTemplatePaths.swift
@@ -22,6 +22,9 @@ public struct TagTemplatePaths {
     /// Path to template for textarea element
     public let textareaField: String
 
+    /// Path to template for select input element
+    public let selectField: String
+
     /// Create a new TagTemplatePaths configuration value.
     ///
     /// - Parameters:
@@ -39,7 +42,8 @@ public struct TagTemplatePaths {
         hiddenField: String = "Submissions/Fields/hidden-input",
         passwordField: String = "Submissions/Fields/password-input",
         textField: String = "Submissions/Fields/text-input",
-        textareaField: String = "Submissions/Fields/textarea-input"
+        textareaField: String = "Submissions/Fields/textarea-input",
+        selectField: String = "Submissions/Fields/select-input"
     ) {
         self.checkboxField = checkboxField
         self.emailField = emailField
@@ -48,5 +52,6 @@ public struct TagTemplatePaths {
         self.passwordField = passwordField
         self.textField = textField
         self.textareaField = textareaField
+        self.selectField = selectField
     }
 }


### PR DESCRIPTION
Example usage

```
#submissions:select("myElementKey", options, "My label", "My help text")
```

Options can be passed in as:
```swift
extension MyModel: Selectable {
    func optionID() throws -> String? {
        guard let id = self.id else { return nil }
        return String(id)
    }

    func optionValue() throws -> String? {
        return self.someValue
    }
}
```

`[MyModel]` can then be passed to Leaf by passing on `[MyModel].options`

This should close https://github.com/nodes-vapor/submissions/issues/42 and https://github.com/nodes-vapor/submissions/issues/31 (I suggest a multiple select becomes another tag - which I can prepare in another another PR)