### PR TITLE
Make SubmissionsMiddleware ServiceType compliant to add middleware in config as the rest of vapor's available middleware (coding style more than a real improvement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ First make sure that you've imported Submissions everywhere it's needed:
 import Submissions
 ```
 
-### Adding the Provider
+### Adding the Provider and Middleware
 
 "Submissions" comes with a light-weight provider that we'll need to register in the `configure` function in our `configure.swift` file:
 
@@ -56,7 +56,14 @@ import Submissions
 try services.register(SubmissionsProvider())
 ```
 
+It also include a middleware you have to register in your `MiddlewareConfig` :
+
+```swift
+config.use(SubmissionsMiddleware.self)
+```
+
 This makes sure that fields and errors can be stored on the request using a `FieldCache` service.
+
 
 ## Validating API requests
 

--- a/Sources/Submissions/SubmissionsMiddleware.swift
+++ b/Sources/Submissions/SubmissionsMiddleware.swift
@@ -5,8 +5,13 @@ import Vapor
 /// Note: needs to come after `ErrorMiddleware` (if present) to avoid the
 /// `SubmissionValidationError`s from being transformed into Internal Server errors on the way back
 /// up the responder chain.
-public final class SubmissionsMiddleware: Middleware {
+public final class SubmissionsMiddleware: Middleware, ServiceType {
 
+	/// See `ServiceType`.
+	public static func makeService(for container: Container) throws -> SubmissionsMiddleware {
+		return SubmissionsMiddleware()
+	}
+	
     /// Create a new `SubmissionsMiddleware`.
     public init() {}
 


### PR DESCRIPTION
Self-describing (and from #48)