### PR TITLE
Add `getAllErrors(on:)` to `FieldCache` for retrieving all submission errors

### DIFF
--- a/Sources/Submissions/Models/FieldCache.swift
+++ b/Sources/Submissions/Models/FieldCache.swift
@@ -40,9 +40,6 @@ extension FieldCache {
         }
         .flatten(on: worker)
         .map(Dictionary.init(uniqueKeysWithValues:)) // safe to use because we know keys will be unique
-        .map { dict in
-            return dict
-        }
     }
 }
 

--- a/Sources/Submissions/Models/FieldCache.swift
+++ b/Sources/Submissions/Models/FieldCache.swift
@@ -32,6 +32,18 @@ extension FieldCache {
             fields[key] = newValue
         }
     }
+
+    /// Returns the errors for all fields.
+    public func getAllErrors(on worker: Worker) -> EventLoopFuture<[String: [String]]> {
+        return errors.map { key, errorsFuture in
+            errorsFuture.map { errors in (key, errors) }
+        }
+        .flatten(on: worker)
+        .map(Dictionary.init(uniqueKeysWithValues:)) // safe to use because we know keys will be unique
+        .map { dict in
+            return dict
+        }
+    }
 }
 
 extension Request {


### PR DESCRIPTION
Add `getAllErrors(on:)` to `FieldCache` for retrieving all submission errors