### PR TITLE
Use specific func name to avoid conflicts

### DIFF
--- a/Sources/Submissions/UpdateRequest.swift
+++ b/Sources/Submissions/UpdateRequest.swift
@@ -21,7 +21,7 @@ public extension UpdateRequest {
 }
 
 public extension UpdateRequest where Model: Authenticatable {
-    static func update(on request: Request) -> EventLoopFuture<Model> {
+    static func updateAuthenticatable(on request: Request) -> EventLoopFuture<Model> {
         do {
             return update(try request.auth.require(), on: request)
         } catch {


### PR DESCRIPTION
There can be competing implementations when model conforms to multiple
protocols that enable fetching a model given a request.