### PR TITLE
UpdateRequest != ValidatableRequest

### DIFF
--- a/Sources/Submissions/RequestMakeable.swift
+++ b/Sources/Submissions/RequestMakeable.swift
@@ -6,10 +6,6 @@ public protocol RequestMakeable {
 
 public extension RequestMakeable where Self: Decodable {
     static func make(from request: Request) -> EventLoopFuture<Self> {
-        do {
-            return request.eventLoop.future(try request.content.decode(Self.self))
-        } catch {
-            return request.eventLoop.future(error: error)
-        }
+        request.eventLoop.future(result: .init { try request.content.decode(Self.self) })
     }
 }

--- a/Sources/Submissions/UpdateRequest.swift
+++ b/Sources/Submissions/UpdateRequest.swift
@@ -33,11 +33,7 @@ public extension UpdateRequest {
 }
 
 public extension UpdateRequest where Model: Authenticatable {
-    static func create(on request: Request) -> EventLoopFuture<Model> {
-        do {
-            return request.eventLoop.future(try request.auth.require())
-        } catch {
-            return request.eventLoop.makeFailedFuture(error)
-        }
+    static func find(on request: Request) -> EventLoopFuture<Model> {
+        request.eventLoop.future(result: .init { try request.auth.require() })
     }
 }

--- a/Sources/Submissions/UpdateRequest.swift
+++ b/Sources/Submissions/UpdateRequest.swift
@@ -1,37 +1,41 @@
 import Vapor
 
-public protocol UpdateRequest: ValidatableRequest {
+public protocol UpdateRequest: RequestMakeable {
     associatedtype Model
 
-    func update(_ model: Model, on request: Request) -> EventLoopFuture<Model>
-
+    static func find(on request: Request) -> EventLoopFuture<Model>
     static func validations(for model: Model, on request: Request) -> EventLoopFuture<Validations>
+
+    func update(_ model: Model, on request: Request) -> EventLoopFuture<Model>
 }
 
-extension UpdateRequest {
-    static func validations(for model: Model, on request: Request) -> EventLoopFuture<Validations> {
-        validations(on: request)
+public extension UpdateRequest {
+    static func validations(
+        for _: Model,
+        on request: Request
+    ) -> EventLoopFuture<Validations> {
+        request.eventLoop.future(Validations())
     }
 }
 
 public extension UpdateRequest {
-    static func update(_ model: Model, on request: Request) -> EventLoopFuture<Model> {
-        validated(for: model, on: request).flatMap { $0.update(model, on: request) }
-    }
-
-    static func validated(for model: Model, on request: Request) -> EventLoopFuture<Self> {
-        validations(for: model, on: request).flatMapThrowing { validations in
-            try validations.validate(request).assert()
-        }.flatMap {
-            make(from: request)
+    static func update(on request: Request) -> EventLoopFuture<Model> {
+        find(on: request).flatMap { model in
+            validations(for: model, on: request).flatMapThrowing { validations in
+                try validations.validate(request).assert()
+            }.flatMap {
+                make(from: request)
+            }.flatMap {
+                $0.update(model, on: request)
+            }
         }
     }
 }
 
 public extension UpdateRequest where Model: Authenticatable {
-    static func updateAuthenticatable(on request: Request) -> EventLoopFuture<Model> {
+    static func create(on request: Request) -> EventLoopFuture<Model> {
         do {
-            return update(try request.auth.require(), on: request)
+            return request.eventLoop.future(try request.auth.require())
         } catch {
             return request.eventLoop.makeFailedFuture(error)
         }

--- a/Tests/SubmissionsTests/Controllers/PostController.swift
+++ b/Tests/SubmissionsTests/Controllers/PostController.swift
@@ -7,10 +7,7 @@ struct PostController {
     }
 
     func update(request: Request) -> EventLoopFuture<Post> {
-        //find the post
-        let post = Post(title: "")
-        //and update it
-        return UpdatePostRequest.update(post, on: request)
+        UpdatePostRequest.update(on: request)
     }
 }
 

--- a/Tests/SubmissionsTests/Models/Requests/UpdatePostRequest.swift
+++ b/Tests/SubmissionsTests/Models/Requests/UpdatePostRequest.swift
@@ -2,9 +2,21 @@ import Vapor
 import Submissions
 
 struct UpdatePostRequest: Content, UpdateRequest {
+    static func find(on request: Request) -> EventLoopFuture<Post> {
+        // Here we return a new, empty post
+        //
+        // Real world implementations could include:
+        // - loading a model from the database
+        // - getting the model from the authentication cache (updating logged-in user)
+        request.eventLoop.future(Post(title: ""))
+    }
+
     let title: String?
 
-    static func validations(for model: Post, on request: Request) -> EventLoopFuture<Validations> {
+    static func validations(
+        for _: Post,
+        on request: Request
+    ) -> EventLoopFuture<Validations> {
         var validations = Validations()
         if request.url.query == "fail" {
             validations.add("validation", result: ValidatorResults.TestFailure())


### PR DESCRIPTION
By making UpdateRequest have its own approach to validations we remove
a lot of potential confusion as to where validations should be added.