### PR TITLE
Fix for breaking change to validations in Vapor >= 4.22.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Submissions", targets: ["Submissions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0")
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.22.0")
     ],
     targets: [
         .target(name: "Submissions", dependencies: [.product(name: "Vapor", package: "vapor")]),

--- a/Sources/Submissions/UpdateRequest.swift
+++ b/Sources/Submissions/UpdateRequest.swift
@@ -22,7 +22,7 @@ public extension UpdateRequest {
     static func update(on request: Request) -> EventLoopFuture<Model> {
         find(on: request).flatMap { model in
             validations(for: model, on: request).flatMapThrowing { validations in
-                try validations.validate(request).assert()
+                try validations.validate(request: request).assert()
             }.flatMap {
                 make(from: request)
             }.flatMap {

--- a/Sources/Submissions/ValidatableRequest.swift
+++ b/Sources/Submissions/ValidatableRequest.swift
@@ -19,7 +19,7 @@ public extension ValidatableRequest where Self: Validatable {
 public extension ValidatableRequest {
     static func validated(on request: Request) -> EventLoopFuture<Self> {
         validations(on: request).flatMapThrowing { validations in
-            try validations.validate(request).assert()
+            try validations.validate(request: request).assert()
         }.flatMap {
             make(from: request)
         }


### PR DESCRIPTION
Method signature `validate(_ request:)` has changed to `validate(request:)`, which was failing builds. 