### PR TITLE
Use Validatable's conformance for UpdateRequest

### DIFF
--- a/Sources/Submissions/UpdateRequest.swift
+++ b/Sources/Submissions/UpdateRequest.swift
@@ -37,3 +37,9 @@ public extension UpdateRequest where Model: Authenticatable {
         request.eventLoop.future(result: .init { try request.auth.require() })
     }
 }
+
+public extension UpdateRequest where Self: Validatable {
+    static func validations(for _: Model, on request: Request) -> EventLoopFuture<Validations> {
+        request.eventLoop.future(validations())
+    }
+}


### PR DESCRIPTION
This allows one to use the simpler `Validatable` conformance for creating validations instead of the one from `UpdateRequest`.

You can use this if you don't need the existing model nor the `Request` and if your validations don't need to be created asynchronously.